### PR TITLE
Implement routing

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,8 +6,12 @@
     <title>Chortle - The Chore Chart App</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
     <link rel="stylesheet" href="main.css">
+    <script type="module">
+        import van from 'https://cdn.jsdelivr.net/gh/vanjs-org/van/public/van-1.5.5.min.js';
+        window.van = van;
+    </script>
+    <script type="module" src="main.js"></script>
 </head>
 <body>
-    <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/docs/main.js
+++ b/docs/main.js
@@ -1,7 +1,16 @@
-import van from "https://cdn.jsdelivr.net/gh/vanjs-org/van/public/van-1.5.5.min.js"
+import routes from './routes.js'
 
-const { div } = van.tags
+const content = van.state(() => "")
 
-const app = div("Welcome to chortle")
+function renderRoute() {
+    const hash = location.hash.substring(1)
+    content.val = routes[hash] || routes.notFound
+}
 
-van.add(document.body, app)
+function start() {
+    van.add(document.body, () => content.val())
+    renderRoute();
+}
+
+window.addEventListener('hashchange', renderRoute)
+window.addEventListener('DOMContentLoaded', start)

--- a/docs/pages/about.js
+++ b/docs/pages/about.js
@@ -1,0 +1,5 @@
+const { div } = van.tags
+
+export default () => {
+    return div("About page")
+}

--- a/docs/pages/home.js
+++ b/docs/pages/home.js
@@ -1,0 +1,5 @@
+const { div } = van.tags
+
+export default () => {
+    return div("Welcome to chortle")
+}

--- a/docs/pages/notFound.js
+++ b/docs/pages/notFound.js
@@ -1,0 +1,5 @@
+const { div } = van.tags
+
+export default () => {
+    return div("Page not found")
+}

--- a/docs/routes.js
+++ b/docs/routes.js
@@ -1,0 +1,10 @@
+import home from './pages/home.js'
+import about from './pages/about.js'
+import notFound from './pages/notFound.js'
+
+export default {
+    '': home,
+    home,
+    about,
+    notFound
+}


### PR DESCRIPTION
Goal was to keep it super slim, and super simple.

New pages are added as JS modules to the `docs/pages` directory.

Pages export a default function with the VanJS content.

The route is then imported into `routes.js` and added to the export object.

That's all that's required.

Additionally:
Moved the vanjs import to the HTML so that we can add it to the window object and use it globally, without having to import it in every file.